### PR TITLE
Pull message sending out into a service

### DIFF
--- a/src/main/java/com/agonyforge/core/config/InterpreterAutoConfiguration.java
+++ b/src/main/java/com/agonyforge/core/config/InterpreterAutoConfiguration.java
@@ -6,6 +6,7 @@ import com.agonyforge.core.controller.interpret.InGameInterpreterDelegate;
 import com.agonyforge.core.controller.interpret.LoginInterpreterDelegate;
 import com.agonyforge.core.repository.ConnectionRepository;
 import com.agonyforge.core.repository.CreatureRepository;
+import com.agonyforge.core.service.CommService;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -23,6 +24,7 @@ public class InterpreterAutoConfiguration {
     private SessionRepository sessionRepository;
     private ConnectionRepository connectionRepository;
     private CreatureRepository creatureRepository;
+    private CommService commService;
 
     @Inject
     public InterpreterAutoConfiguration(
@@ -31,7 +33,8 @@ public class InterpreterAutoConfiguration {
         AuthenticationManager authenticationManager,
         SessionRepository sessionRepository,
         ConnectionRepository connectionRepository,
-        CreatureRepository creatureRepository) {
+        CreatureRepository creatureRepository,
+        CommService commService) {
 
         this.loginConfiguration = loginConfiguration;
         this.userDetailsManager = userDetailsManager;
@@ -39,6 +42,7 @@ public class InterpreterAutoConfiguration {
         this.sessionRepository = sessionRepository;
         this.connectionRepository = connectionRepository;
         this.creatureRepository = creatureRepository;
+        this.commService = commService;
     }
 
     @Bean
@@ -50,13 +54,17 @@ public class InterpreterAutoConfiguration {
             authenticationManager,
             sessionRepository,
             connectionRepository,
-            creatureRepository
+            creatureRepository,
+            commService
         );
     }
 
     @Bean
     @ConditionalOnMissingBean(InGameInterpreterDelegate.class)
     public InGameInterpreterDelegate inGameInterpreterDelegate() {
-        return new DefaultInGameInterpreterDelegate(creatureRepository, loginConfiguration);
+        return new DefaultInGameInterpreterDelegate(
+            creatureRepository,
+            loginConfiguration,
+            commService);
     }
 }

--- a/src/main/java/com/agonyforge/core/controller/interpret/BaseInterpreter.java
+++ b/src/main/java/com/agonyforge/core/controller/interpret/BaseInterpreter.java
@@ -3,50 +3,11 @@ package com.agonyforge.core.controller.interpret;
 import com.agonyforge.core.controller.Input;
 import com.agonyforge.core.controller.Output;
 import com.agonyforge.core.model.Connection;
-import com.agonyforge.core.model.Creature;
-import com.agonyforge.core.repository.CreatureRepository;
-import org.springframework.messaging.simp.SimpMessagingTemplate;
-
-import java.util.Arrays;
-import java.util.List;
 
 public abstract class BaseInterpreter implements Interpreter {
-    private CreatureRepository creatureRepository;
-    private SimpMessagingTemplate simpMessagingTemplate;
-
     @Override
     public abstract Output interpret(Input input, Connection connection);
 
     @Override
     public abstract Output prompt(Connection connection);
-
-    public BaseInterpreter(CreatureRepository creatureRepository, SimpMessagingTemplate simpMessagingTemplate) {
-        this.creatureRepository = creatureRepository;
-        this.simpMessagingTemplate = simpMessagingTemplate;
-    }
-
-    public void echo(Creature target, Output message) {
-        if (target.getConnection() == null || target.getConnection().getSessionUsername() == null) {
-            return;
-        }
-
-        message.append(prompt(target.getConnection()));
-
-        simpMessagingTemplate.convertAndSendToUser(
-            target.getConnection().getSessionUsername(),
-            "/queue/output",
-            message);
-    }
-
-    public void echoToWorld(Output message, Creature ... exclude) {
-        List<Creature> excludeList = Arrays.asList(exclude);
-
-        creatureRepository.findByConnectionIsNotNull()
-            .filter(target -> target.getConnection().getSessionUsername() != null)
-            .filter(target -> !excludeList.contains(target))
-            .forEach(target -> simpMessagingTemplate.convertAndSendToUser(
-                target.getConnection().getSessionUsername(),
-                "/queue/output",
-                new Output(message, prompt(target.getConnection()))));
-    }
 }

--- a/src/main/java/com/agonyforge/core/controller/interpret/DefaultInGameInterpreterDelegate.java
+++ b/src/main/java/com/agonyforge/core/controller/interpret/DefaultInGameInterpreterDelegate.java
@@ -6,17 +6,21 @@ import com.agonyforge.core.controller.Output;
 import com.agonyforge.core.model.Connection;
 import com.agonyforge.core.model.Creature;
 import com.agonyforge.core.repository.CreatureRepository;
+import com.agonyforge.core.service.CommService;
 
 public class DefaultInGameInterpreterDelegate implements InGameInterpreterDelegate {
     private CreatureRepository creatureRepository;
     private LoginConfiguration loginConfiguration; // TODO need to break this configuration apart
+    private CommService commService;
 
     public DefaultInGameInterpreterDelegate(
         CreatureRepository creatureRepository,
-        LoginConfiguration loginConfiguration) {
+        LoginConfiguration loginConfiguration,
+        CommService commService) {
 
         this.creatureRepository = creatureRepository;
         this.loginConfiguration = loginConfiguration;
+        this.commService = commService;
     }
 
     @Override
@@ -29,7 +33,7 @@ public class DefaultInGameInterpreterDelegate implements InGameInterpreterDelega
         output
             .append("[green]You gossip '" + input.toString() + "[green]'")
             .append(primary.prompt(connection));
-        primary.echoToWorld(new Output("[green]" + connection.getName() + " gossips '" + input.toString() + "[green]'"), creature);
+        commService.echoToWorld(new Output("[green]" + connection.getName() + " gossips '" + input.toString() + "[green]'"), primary, creature);
 
         return output;
     }

--- a/src/main/java/com/agonyforge/core/controller/interpret/DefaultLoginInterpreterDelegate.java
+++ b/src/main/java/com/agonyforge/core/controller/interpret/DefaultLoginInterpreterDelegate.java
@@ -8,6 +8,7 @@ import com.agonyforge.core.model.Creature;
 import com.agonyforge.core.model.DefaultLoginConnectionState;
 import com.agonyforge.core.repository.ConnectionRepository;
 import com.agonyforge.core.repository.CreatureRepository;
+import com.agonyforge.core.service.CommService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.security.authentication.AuthenticationManager;
@@ -44,6 +45,7 @@ public class DefaultLoginInterpreterDelegate implements LoginInterpreterDelegate
     private SessionRepository sessionRepository;
     private ConnectionRepository connectionRepository;
     private CreatureRepository creatureRepository;
+    private CommService commService;
 
     public DefaultLoginInterpreterDelegate(
         LoginConfiguration loginConfiguration,
@@ -51,7 +53,8 @@ public class DefaultLoginInterpreterDelegate implements LoginInterpreterDelegate
         AuthenticationManager authenticationManager,
         SessionRepository sessionRepository,
         ConnectionRepository connectionRepository,
-        CreatureRepository creatureRepository) {
+        CreatureRepository creatureRepository,
+        CommService commService) {
 
         this.loginConfiguration = loginConfiguration;
         this.userDetailsManager = userDetailsManager;
@@ -60,6 +63,7 @@ public class DefaultLoginInterpreterDelegate implements LoginInterpreterDelegate
         this.sessionRepository = sessionRepository;
         this.connectionRepository = connectionRepository;
         this.creatureRepository = creatureRepository;
+        this.commService = commService;
     }
 
     @Transactional
@@ -271,7 +275,7 @@ public class DefaultLoginInterpreterDelegate implements LoginInterpreterDelegate
 
             connectionRepository.save(oldConnection);
 
-            primary.echo(creature, new Output("[yellow]This character has been reconnected in another browser. Goodbye!"));
+            commService.echo(creature, primary, new Output("[yellow]This character has been reconnected in another browser. Goodbye!"));
         }
 
         creature.setConnection(connection);

--- a/src/main/java/com/agonyforge/core/controller/interpret/DefaultPrimaryInterpreter.java
+++ b/src/main/java/com/agonyforge/core/controller/interpret/DefaultPrimaryInterpreter.java
@@ -4,10 +4,8 @@ import com.agonyforge.core.controller.Input;
 import com.agonyforge.core.controller.Output;
 import com.agonyforge.core.model.Connection;
 import com.agonyforge.core.model.PrimaryConnectionState;
-import com.agonyforge.core.repository.CreatureRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Component;
 
 import javax.inject.Inject;
@@ -21,12 +19,8 @@ public class DefaultPrimaryInterpreter extends BaseInterpreter {
 
     @Inject
     public DefaultPrimaryInterpreter(
-        CreatureRepository creatureRepository,
-        SimpMessagingTemplate simpMessagingTemplate,
         LoginInterpreterDelegate loginInterpreterDelegate,
         InGameInterpreterDelegate inGameInterpreterDelegate) {
-
-        super(creatureRepository, simpMessagingTemplate);
 
         this.loginInterpreter = loginInterpreterDelegate;
         this.inGameInterpreter = inGameInterpreterDelegate;

--- a/src/main/java/com/agonyforge/core/controller/interpret/Interpreter.java
+++ b/src/main/java/com/agonyforge/core/controller/interpret/Interpreter.java
@@ -3,11 +3,8 @@ package com.agonyforge.core.controller.interpret;
 import com.agonyforge.core.controller.Input;
 import com.agonyforge.core.controller.Output;
 import com.agonyforge.core.model.Connection;
-import com.agonyforge.core.model.Creature;
 
 public interface Interpreter {
     Output interpret(Input input, Connection connection);
     Output prompt(Connection connection);
-    void echo(Creature target, Output message);
-    void echoToWorld(Output message, Creature... exclude);
 }

--- a/src/main/java/com/agonyforge/core/service/CommService.java
+++ b/src/main/java/com/agonyforge/core/service/CommService.java
@@ -1,0 +1,52 @@
+package com.agonyforge.core.service;
+
+import com.agonyforge.core.controller.Output;
+import com.agonyforge.core.controller.interpret.Interpreter;
+import com.agonyforge.core.model.Creature;
+import com.agonyforge.core.repository.CreatureRepository;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Component;
+
+import javax.inject.Inject;
+import java.util.Arrays;
+import java.util.List;
+
+@Component
+public class CommService {
+    private CreatureRepository creatureRepository;
+    private SimpMessagingTemplate simpMessagingTemplate;
+
+    @Inject
+    public CommService(
+        CreatureRepository creatureRepository,
+        SimpMessagingTemplate simpMessagingTemplate) {
+
+        this.creatureRepository = creatureRepository;
+        this.simpMessagingTemplate = simpMessagingTemplate;
+    }
+
+    public void echo(Creature target, Interpreter interpreter, Output message) {
+        if (target.getConnection() == null || target.getConnection().getSessionUsername() == null) {
+            return;
+        }
+
+        message.append(interpreter.prompt(target.getConnection()));
+
+        simpMessagingTemplate.convertAndSendToUser(
+            target.getConnection().getSessionUsername(),
+            "/queue/output",
+            message);
+    }
+
+    public void echoToWorld(Output message, Interpreter interpreter, Creature ... exclude) {
+        List<Creature> excludeList = Arrays.asList(exclude);
+
+        creatureRepository.findByConnectionIsNotNull()
+            .filter(target -> target.getConnection().getSessionUsername() != null)
+            .filter(target -> !excludeList.contains(target))
+            .forEach(target -> simpMessagingTemplate.convertAndSendToUser(
+                target.getConnection().getSessionUsername(),
+                "/queue/output",
+                new Output(message, interpreter.prompt(target.getConnection()))));
+    }
+}

--- a/src/test/java/com/agonyforge/core/controller/interpret/DefaultInGameInterpreterDelegateTest.java
+++ b/src/test/java/com/agonyforge/core/controller/interpret/DefaultInGameInterpreterDelegateTest.java
@@ -6,6 +6,7 @@ import com.agonyforge.core.controller.Output;
 import com.agonyforge.core.model.Connection;
 import com.agonyforge.core.model.Creature;
 import com.agonyforge.core.repository.CreatureRepository;
+import com.agonyforge.core.service.CommService;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -27,6 +28,9 @@ public class DefaultInGameInterpreterDelegateTest {
     @Mock
     private Interpreter primary;
 
+    @Mock
+    private CommService commService;
+
     private DefaultInGameInterpreterDelegate interpreter;
     private Creature me = new Creature();
 
@@ -47,7 +51,8 @@ public class DefaultInGameInterpreterDelegateTest {
 
         interpreter = new DefaultInGameInterpreterDelegate(
             creatureRepository,
-            loginConfiguration
+            loginConfiguration,
+            commService
         );
     }
 
@@ -63,7 +68,7 @@ public class DefaultInGameInterpreterDelegateTest {
         assertTrue(output.toString().contains("You gossip"));
         assertTrue(output.toString().contains(input.toString()));
 
-        verify(primary).echoToWorld(any(), eq(me));
+        verify(commService).echoToWorld(any(), eq(primary), eq(me));
     }
 
     @Test

--- a/src/test/java/com/agonyforge/core/controller/interpret/DefaultLoginInterpreterDelegateTest.java
+++ b/src/test/java/com/agonyforge/core/controller/interpret/DefaultLoginInterpreterDelegateTest.java
@@ -7,6 +7,7 @@ import com.agonyforge.core.model.Connection;
 import com.agonyforge.core.model.Creature;
 import com.agonyforge.core.repository.ConnectionRepository;
 import com.agonyforge.core.repository.CreatureRepository;
+import com.agonyforge.core.service.CommService;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
@@ -50,6 +51,9 @@ public class DefaultLoginInterpreterDelegateTest {
 
     @Mock
     private CreatureRepository creatureRepository;
+
+    @Mock
+    private CommService commService;
 
     @Mock
     private Session session;
@@ -99,7 +103,8 @@ public class DefaultLoginInterpreterDelegateTest {
             authenticationManager,
             sessionRepository,
             connectionRepository,
-            creatureRepository);
+            creatureRepository,
+            commService);
     }
 
     @Test
@@ -174,7 +179,7 @@ public class DefaultLoginInterpreterDelegateTest {
         assertEquals(DISCONNECTED, oldConnection.getPrimaryState());
         assertEquals(DEFAULT_SECONDARY_STATE, oldConnection.getSecondaryState());
 
-        verify(primary).echo(eq(creature), any());
+        verify(commService).echo(eq(creature), eq(primary), any());
         verify(connectionRepository).save(eq(oldConnection));
         verify(creatureRepository).save(eq(creature));
     }

--- a/src/test/java/com/agonyforge/core/controller/interpret/DefaultPrimaryInterpreterTest.java
+++ b/src/test/java/com/agonyforge/core/controller/interpret/DefaultPrimaryInterpreterTest.java
@@ -3,12 +3,10 @@ package com.agonyforge.core.controller.interpret;
 import com.agonyforge.core.controller.Input;
 import com.agonyforge.core.controller.Output;
 import com.agonyforge.core.model.Connection;
-import com.agonyforge.core.repository.CreatureRepository;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import org.springframework.messaging.simp.SimpMessagingTemplate;
 
 import static com.agonyforge.core.model.PrimaryConnectionState.*;
 import static org.junit.Assert.assertEquals;
@@ -17,12 +15,6 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
 public class DefaultPrimaryInterpreterTest {
-    @Mock
-    private CreatureRepository creatureRepository;
-
-    @Mock
-    private SimpMessagingTemplate simpMessagingTemplate;
-
     @Mock
     private LoginInterpreterDelegate loginInterpreterDelegate;
 
@@ -36,8 +28,6 @@ public class DefaultPrimaryInterpreterTest {
         MockitoAnnotations.initMocks(this);
 
         primary = new DefaultPrimaryInterpreter(
-            creatureRepository,
-            simpMessagingTemplate,
             loginInterpreterDelegate,
             inGameInterpreterDelegate
         );

--- a/src/test/java/com/agonyforge/core/controller/interpret/EchoInterpreter.java
+++ b/src/test/java/com/agonyforge/core/controller/interpret/EchoInterpreter.java
@@ -3,19 +3,10 @@ package com.agonyforge.core.controller.interpret;
 import com.agonyforge.core.controller.Input;
 import com.agonyforge.core.controller.Output;
 import com.agonyforge.core.model.Connection;
-import com.agonyforge.core.repository.CreatureRepository;
-import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Component;
-
-import javax.inject.Inject;
 
 @Component
 public class EchoInterpreter extends BaseInterpreter {
-    @Inject
-    public EchoInterpreter(CreatureRepository creatureRepository, SimpMessagingTemplate simpMessagingTemplate) {
-        super(creatureRepository, simpMessagingTemplate);
-    }
-
     @Override
     public Output interpret(Input input, Connection connection) {
         return new Output("[cyan]" + input).append(prompt(connection));


### PR DESCRIPTION
Down the road when it's time to start writing commands and all the other things that send messages to players it will be necessary to have a flexible way of doing that, since all that code won't live inside of the Interpreter and its delegates.