### PR TITLE
Role framework

### DIFF
--- a/src/main/java/com/agonyforge/core/controller/interpret/delegate/game/binding/VerbBinding.java
+++ b/src/main/java/com/agonyforge/core/controller/interpret/delegate/game/binding/VerbBinding.java
@@ -34,6 +34,12 @@ public class VerbBinding implements ArgumentBinding {
             return false;
         }
 
+        if (actor.getRoles().stream().noneMatch(role -> "SUPER".equals(role.getName()))
+            && actor.getRoles().stream().noneMatch(actorRole -> verbOptional.get().getRoles().contains(actorRole))) {
+
+            return false;
+        }
+
         this.verb = verbOptional.get();
         return true;
     }

--- a/src/main/java/com/agonyforge/core/controller/interpret/delegate/game/command/HelpCommand.java
+++ b/src/main/java/com/agonyforge/core/controller/interpret/delegate/game/command/HelpCommand.java
@@ -1,7 +1,6 @@
 package com.agonyforge.core.controller.interpret.delegate.game.command;
 
 import com.agonyforge.core.controller.Output;
-import com.agonyforge.core.controller.interpret.delegate.game.binding.QuotedString;
 import com.agonyforge.core.controller.interpret.delegate.game.binding.VerbBinding;
 import com.agonyforge.core.model.Creature;
 import com.agonyforge.core.model.Verb;
@@ -13,7 +12,6 @@ import org.springframework.stereotype.Component;
 import javax.inject.Inject;
 import javax.transaction.Transactional;
 import java.util.List;
-import java.util.Optional;
 
 @Component
 public class HelpCommand {
@@ -32,7 +30,10 @@ public class HelpCommand {
         List<Verb> allVerbs = verbRepository.findAll(Sort.by(Sort.Direction.ASC, "name"));
 
         output.append("[default]All Commands:");
-        allVerbs.forEach(verb -> output.append(String.format("[default]%s", verb.getName())));
+        allVerbs
+            .stream()
+            .filter(verb -> verb.getRoles().stream().anyMatch(verbRole -> actor.getRoles().contains(verbRole)))
+            .forEach(verb -> output.append(String.format("[default]%s", verb.getName())));
     }
 
     @Transactional

--- a/src/main/java/com/agonyforge/core/controller/interpret/delegate/game/command/SuperCommand.java
+++ b/src/main/java/com/agonyforge/core/controller/interpret/delegate/game/command/SuperCommand.java
@@ -1,0 +1,81 @@
+package com.agonyforge.core.controller.interpret.delegate.game.command;
+
+import com.agonyforge.core.controller.Output;
+import com.agonyforge.core.model.Creature;
+import com.agonyforge.core.model.Role;
+import com.agonyforge.core.model.Verb;
+import com.agonyforge.core.model.repository.CreatureRepository;
+import com.agonyforge.core.model.repository.VerbRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.data.domain.Sort;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.provisioning.UserDetailsManager;
+import org.springframework.stereotype.Component;
+
+import javax.inject.Inject;
+import javax.transaction.Transactional;
+import java.util.ArrayList;
+import java.util.List;
+
+@Component
+public class SuperCommand {
+    private static final Logger LOGGER = LoggerFactory.getLogger(SuperCommand.class);
+
+    private UserDetailsManager userDetailsManager;
+    private CreatureRepository creatureRepository;
+    private VerbRepository verbRepository;
+
+    @Inject
+    public SuperCommand(
+        @SuppressWarnings("SpringJavaInjectionPointsAutowiringInspection") UserDetailsManager userDetailsManager,
+        CreatureRepository creatureRepository,
+        VerbRepository verbRepository) {
+
+        this.userDetailsManager = userDetailsManager;
+        this.creatureRepository = creatureRepository;
+        this.verbRepository = verbRepository;
+    }
+
+    @Transactional
+    @CommandDescription("Gives you the SUPER role")
+    public void invoke(Creature actor, Output output) {
+        Verb verb = verbRepository
+            .findFirstByNameIgnoreCaseStartingWith(Sort.by(Sort.Direction.ASC, "priority", "name"), "super")
+            .orElseThrow(() -> new NullPointerException("Cannot find \"super\" verb!"));
+
+        if (!verb.getRoles().contains(new Role("PLAYER"))) {
+            LOGGER.warn("{} attempted to use the SUPER command, but it has already been used", actor.getName());
+            output.append("[red]This command may only be used once.");
+            return;
+        }
+
+        User user = (User) userDetailsManager.loadUserByUsername(actor.getName());
+        List<GrantedAuthority> authorities = new ArrayList<>(user.getAuthorities());
+
+        authorities.add(new SimpleGrantedAuthority("SUPER"));
+
+        User updatedUser = new User(
+            user.getUsername(),
+            user.getPassword(),
+            user.isEnabled(),
+            user.isAccountNonExpired(),
+            user.isCredentialsNonExpired(),
+            user.isAccountNonLocked(),
+            authorities);
+
+        actor.getRoles().add(new Role("SUPER"));
+
+        userDetailsManager.updateUser(updatedUser);
+        creatureRepository.save(actor);
+
+        verb.getRoles().clear();
+        verbRepository.save(verb);
+
+        LOGGER.warn("{} successfully used the SUPER command!", actor.getName());
+
+        output.append("[yellow]BAMF!");
+    }
+}

--- a/src/main/java/com/agonyforge/core/model/Creature.java
+++ b/src/main/java/com/agonyforge/core/model/Creature.java
@@ -9,9 +9,12 @@ import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
+import javax.persistence.ManyToMany;
 import javax.persistence.ManyToOne;
 import javax.persistence.OneToOne;
+import java.util.HashSet;
 import java.util.Objects;
+import java.util.Set;
 import java.util.UUID;
 
 @Entity
@@ -29,6 +32,9 @@ public class Creature {
 
     @Enumerated(EnumType.STRING)
     private Gender gender;
+
+    @ManyToMany(cascade = CascadeType.ALL)
+    private Set<Role> roles = new HashSet<>();
 
     @OneToOne(cascade = CascadeType.ALL)
     private Connection connection;
@@ -63,6 +69,14 @@ public class Creature {
 
     public void setGender(Gender gender) {
         this.gender = gender;
+    }
+
+    public Set<Role> getRoles() {
+        return roles;
+    }
+
+    public void setRoles(Set<Role> roles) {
+        this.roles = roles;
     }
 
     public Connection getConnection() {

--- a/src/main/java/com/agonyforge/core/model/Role.java
+++ b/src/main/java/com/agonyforge/core/model/Role.java
@@ -1,0 +1,42 @@
+package com.agonyforge.core.model;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import java.util.Objects;
+
+@Entity
+public class Role {
+    public static final String SUPER_ROLE = "SUPER";
+
+    public Role() {
+        // this method intentionally left blank
+    }
+
+    public Role(String name) {
+        this.name = name;
+    }
+
+    @Id
+    private String name;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof Role)) return false;
+        Role role = (Role) o;
+        return Objects.equals(getName(), role.getName());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getName());
+    }
+}

--- a/src/main/java/com/agonyforge/core/model/Verb.java
+++ b/src/main/java/com/agonyforge/core/model/Verb.java
@@ -6,10 +6,14 @@ import com.agonyforge.core.controller.interpret.delegate.game.command.CommandDes
 import org.springframework.core.annotation.AnnotationUtils;
 import org.springframework.util.ReflectionUtils;
 
+import javax.persistence.CascadeType;
 import javax.persistence.Entity;
 import javax.persistence.Id;
+import javax.persistence.ManyToMany;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.Objects;
+import java.util.Set;
 
 import static com.agonyforge.core.service.InvokerService.REQUIRED_ARG_COUNT;
 
@@ -20,6 +24,9 @@ public class Verb {
     private String bean;
     private int priority;
     private boolean quoting = false;
+
+    @ManyToMany(cascade = CascadeType.ALL)
+    private Set<Role> roles = new HashSet<>();
 
     public String getName() {
         return name;
@@ -51,6 +58,14 @@ public class Verb {
 
     public void setQuoting(boolean quoting) {
         this.quoting = quoting;
+    }
+
+    public Set<Role> getRoles() {
+        return roles;
+    }
+
+    public void setRoles(Set<Role> roles) {
+        this.roles = roles;
     }
 
     public static void showVerbSyntax(Verb verb, Object command, Output output) {

--- a/src/main/java/com/agonyforge/core/model/factory/CreatureFactory.java
+++ b/src/main/java/com/agonyforge/core/model/factory/CreatureFactory.java
@@ -5,33 +5,52 @@ import com.agonyforge.core.controller.interpret.Interpreter;
 import com.agonyforge.core.model.Connection;
 import com.agonyforge.core.model.Creature;
 import com.agonyforge.core.model.CreatureDefinition;
+import com.agonyforge.core.model.Role;
 import com.agonyforge.core.model.repository.ConnectionRepository;
 import com.agonyforge.core.model.repository.CreatureRepository;
+import com.agonyforge.core.model.repository.RoleRepository;
 import com.agonyforge.core.service.CommService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.provisioning.UserDetailsManager;
 import org.springframework.stereotype.Component;
 
 import javax.inject.Inject;
+
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Collectors;
 
 import static com.agonyforge.core.controller.interpret.PrimaryConnectionState.DISCONNECTED;
 
 @Component
 public class CreatureFactory {
+    private static final Logger LOGGER = LoggerFactory.getLogger(CreatureFactory.class);
+
     private CommService commService;
     private CreatureRepository creatureRepository;
     private ConnectionRepository connectionRepository;
+    private RoleRepository roleRepository;
+    private UserDetailsManager userDetailsManager;
 
     @Inject
     public CreatureFactory(
         CommService commService,
         CreatureRepository creatureRepository,
-        ConnectionRepository connectionRepository) {
+        ConnectionRepository connectionRepository,
+        RoleRepository roleRepository,
+        @SuppressWarnings("SpringJavaInjectionPointsAutowiringInspection") UserDetailsManager userDetailsManager) {
 
         this.commService = commService;
         this.creatureRepository = creatureRepository;
         this.connectionRepository = connectionRepository;
+        this.roleRepository = roleRepository;
+        this.userDetailsManager = userDetailsManager;
     }
 
     public Creature build(CreatureDefinition definition, Interpreter interpreter, Connection connection) {
+        UserDetails user = userDetailsManager.loadUserByUsername(definition.getName());
         Creature creature = creatureRepository
             .findByDefinition(definition)
             .findFirst()
@@ -41,6 +60,21 @@ public class CreatureFactory {
                 c.setDefinition(definition);
                 c.setName(definition.getName());
                 c.setGender(definition.getGender());
+                c.getRoles().clear();
+                c.getRoles().addAll(user.getAuthorities()
+                    .stream()
+                    .map(authority -> {
+                        Optional<Role> roleOptional = roleRepository.findById(authority.getAuthority());
+
+                        if (roleOptional.isPresent()) {
+                            return roleOptional.get();
+                        }
+
+                        LOGGER.warn("User authority '{}' has no matching Role!", authority.getAuthority());
+                        return null;
+                    })
+                    .filter(Objects::nonNull)
+                    .collect(Collectors.toList()));
 
                 return c;
             });

--- a/src/main/java/com/agonyforge/core/model/repository/RoleRepository.java
+++ b/src/main/java/com/agonyforge/core/model/repository/RoleRepository.java
@@ -1,0 +1,7 @@
+package com.agonyforge.core.model.repository;
+
+import com.agonyforge.core.model.Role;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RoleRepository extends JpaRepository<Role, String> {
+}

--- a/src/main/java/com/agonyforge/core/service/InvokerService.java
+++ b/src/main/java/com/agonyforge/core/service/InvokerService.java
@@ -25,6 +25,8 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static com.agonyforge.core.model.Role.SUPER_ROLE;
+
 @Component
 public class InvokerService {
     public static final int REQUIRED_ARG_COUNT = 2; // every invoke() method requires at least this many arguments
@@ -60,6 +62,14 @@ public class InvokerService {
             return;
         } else {
             output.append("[black]Found verb: " + verbOptional.get().getName() + (verbOptional.get().isQuoting() ? " (quoting)" : ""));
+        }
+
+        if (ch.getRoles().stream().noneMatch(role -> SUPER_ROLE.equals(role.getName())) && verbOptional.get().getRoles().stream().noneMatch(role -> ch.getRoles().contains(role))) {
+            LOGGER.warn("{} has no role to permit use of verb: {}", ch.getName(), verbOptional.get().getName());
+            output.append(String.format("[red]%s has no role to permit use of verb: %s", ch.getName(), verbOptional.get().getName()));
+            return;
+        } else {
+            output.append("[black]Authorization granted for verb: " + verbOptional.get().getName());
         }
 
         if (verbOptional.get().isQuoting()) { // "quoting" verbs automatically enquote everything after the verb into a single token

--- a/src/main/resources/db/migration/R__verbs.sql
+++ b/src/main/resources/db/migration/R__verbs.sql
@@ -5,6 +5,7 @@
 INSERT IGNORE INTO verb (name, priority, bean) VALUES ('help', 0, 'helpCommand');
 INSERT IGNORE INTO verb (name, priority, bean) VALUES ('who', 0, 'whoCommand');
 INSERT IGNORE INTO verb (name, priority, bean, quoting) VALUES ('gossip', 0, 'gossipCommand', TRUE);
+INSERT IGNORE INTO verb (name, priority, bean) VALUES ('super', 1000, 'superCommand');
 
 -- Create the default roles. SUPER is a special role that will let a player run any command.
 INSERT IGNORE INTO role (name) VALUES ('PLAYER');
@@ -14,3 +15,4 @@ INSERT IGNORE INTO role (name) VALUES ('SUPER');
 INSERT IGNORE INTO verb_roles (verb_name, roles_name) VALUES ('help', 'PLAYER');
 INSERT IGNORE INTO verb_roles (verb_name, roles_name) VALUES ('who', 'PLAYER');
 INSERT IGNORE INTO verb_roles (verb_name, roles_name) VALUES ('gossip', 'PLAYER');
+INSERT IGNORE INTO verb_roles (verb_name, roles_name) VALUES ('super', 'PLAYER');

--- a/src/main/resources/db/migration/R__verbs.sql
+++ b/src/main/resources/db/migration/R__verbs.sql
@@ -1,6 +1,16 @@
 -- The INSERT IGNORE syntax will not insert again if the verb is already in the table, in order to avoid overwriting
 -- changes you may have made inside the game.
 
+-- Create the verbs first.
 INSERT IGNORE INTO verb (name, priority, bean) VALUES ('help', 0, 'helpCommand');
 INSERT IGNORE INTO verb (name, priority, bean) VALUES ('who', 0, 'whoCommand');
 INSERT IGNORE INTO verb (name, priority, bean, quoting) VALUES ('gossip', 0, 'gossipCommand', TRUE);
+
+-- Create the default roles. SUPER is a special role that will let a player run any command.
+INSERT IGNORE INTO role (name) VALUES ('PLAYER');
+INSERT IGNORE INTO role (name) VALUES ('SUPER');
+
+-- Associate verbs with roles.
+INSERT IGNORE INTO verb_roles (verb_name, roles_name) VALUES ('help', 'PLAYER');
+INSERT IGNORE INTO verb_roles (verb_name, roles_name) VALUES ('who', 'PLAYER');
+INSERT IGNORE INTO verb_roles (verb_name, roles_name) VALUES ('gossip', 'PLAYER');

--- a/src/main/resources/db/migration/V0005__role_schema.sql
+++ b/src/main/resources/db/migration/V0005__role_schema.sql
@@ -1,0 +1,20 @@
+CREATE TABLE role (
+    name VARCHAR(191) NOT NULL,
+    PRIMARY KEY (name)
+) ENGINE=InnoDB CHARACTER SET=utf8mb4, COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE verb_roles (
+    verb_name VARCHAR(191) NOT NULL,
+    roles_name VARCHAR(191) NOT NULL,
+    PRIMARY KEY (verb_name, roles_name),
+    CONSTRAINT verb_role_1_fk FOREIGN KEY (verb_name) REFERENCES verb (name),
+    CONSTRAINT verb_role_2_fk FOREIGN KEY (roles_name) REFERENCES role (name)
+) ENGINE=InnoDB CHARACTER SET=utf8mb4, COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE creature_roles (
+    creature_id BINARY(16) NOT NULL,
+    roles_name VARCHAR(191) NOT NULL,
+    PRIMARY KEY (creature_id, roles_name),
+    CONSTRAINT creature_role_1_fk FOREIGN KEY (creature_id) REFERENCES creature (id),
+    CONSTRAINT creature_role_2_fk FOREIGN KEY (roles_name) REFERENCES role (name)
+) ENGINE=InnoDB CHARACTER SET=utf8mb4, COLLATE=utf8mb4_unicode_ci;

--- a/src/test/java/com/agonyforge/core/controller/interpret/delegate/game/binding/VerbBindingTest.java
+++ b/src/test/java/com/agonyforge/core/controller/interpret/delegate/game/binding/VerbBindingTest.java
@@ -1,6 +1,7 @@
 package com.agonyforge.core.controller.interpret.delegate.game.binding;
 
 import com.agonyforge.core.model.Creature;
+import com.agonyforge.core.model.Role;
 import com.agonyforge.core.model.Verb;
 import com.agonyforge.core.model.repository.VerbRepository;
 import org.junit.jupiter.api.BeforeEach;
@@ -29,10 +30,15 @@ class VerbBindingTest {
     void setUp() {
         MockitoAnnotations.initMocks(this);
 
+        Role playerRole = new Role("PLAYER");
+
         creature = new Creature();
         verb = new Verb();
 
+        creature.getRoles().add(playerRole);
+
         verb.setName("verb");
+        verb.getRoles().add(playerRole);
 
         when(verbRepository.findFirstByNameIgnoreCaseStartingWith(any(Sort.class), eq("verb"))).thenReturn(Optional.of(verb));
 
@@ -46,8 +52,25 @@ class VerbBindingTest {
     }
 
     @Test
-    void testBindFailure() {
+    void testBindForSuper() {
+        creature.getRoles().clear();
+        creature.getRoles().add(new Role("SUPER"));
+
+        assertTrue(binding.bind(creature, "verb"));
+        assertEquals(verb, binding.getVerb());
+    }
+
+    @Test
+    void testBindFailureNoSuchVerb() {
         assertFalse(binding.bind(creature, "noun"));
+        assertNull(binding.getVerb());
+    }
+
+    @Test
+    void testBindFailureNoMatchingRole() {
+        creature.getRoles().clear();
+
+        assertFalse(binding.bind(creature, "verb"));
         assertNull(binding.getVerb());
     }
 }

--- a/src/test/java/com/agonyforge/core/controller/interpret/delegate/game/command/HelpCommandTest.java
+++ b/src/test/java/com/agonyforge/core/controller/interpret/delegate/game/command/HelpCommandTest.java
@@ -3,6 +3,7 @@ package com.agonyforge.core.controller.interpret.delegate.game.command;
 import com.agonyforge.core.controller.Output;
 import com.agonyforge.core.controller.interpret.delegate.game.binding.VerbBinding;
 import com.agonyforge.core.model.Creature;
+import com.agonyforge.core.model.Role;
 import com.agonyforge.core.model.Verb;
 import com.agonyforge.core.model.repository.VerbRepository;
 import org.junit.jupiter.api.BeforeEach;
@@ -44,6 +45,8 @@ class HelpCommandTest {
         output = new Output();
         verb = new Verb();
 
+        creature.getRoles().add(new Role("PLAYER"));
+
         verb.setName("help");
         verb.setBean("helpCommand");
 
@@ -78,11 +81,13 @@ class HelpCommandTest {
 
     private List<Verb> generateVerbs() {
         List<Verb> verbs = new ArrayList<>();
+        Role playerRole = new Role("PLAYER");
 
         for (int i = 0; i < 5; i++) {
             Verb verb = new Verb();
 
             verb.setName("verb" + i);
+            verb.getRoles().add(playerRole);
             verbs.add(verb);
         }
 

--- a/src/test/java/com/agonyforge/core/controller/interpret/delegate/game/command/SuperCommandTest.java
+++ b/src/test/java/com/agonyforge/core/controller/interpret/delegate/game/command/SuperCommandTest.java
@@ -1,0 +1,83 @@
+package com.agonyforge.core.controller.interpret.delegate.game.command;
+
+import com.agonyforge.core.controller.Output;
+import com.agonyforge.core.model.Creature;
+import com.agonyforge.core.model.Role;
+import com.agonyforge.core.model.Verb;
+import com.agonyforge.core.model.repository.CreatureRepository;
+import com.agonyforge.core.model.repository.VerbRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.data.domain.Sort;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.provisioning.UserDetailsManager;
+
+import java.util.Collections;
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+class SuperCommandTest {
+    @Mock
+    private UserDetailsManager userDetailsManager;
+
+    @Mock
+    private CreatureRepository creatureRepository;
+
+    @Mock
+    private VerbRepository verbRepository;
+
+    private Output output;
+    private Creature creature;
+    private User user;
+    private Verb verb;
+
+    private SuperCommand command;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.initMocks(this);
+
+        output = new Output();
+
+        creature = new Creature();
+        creature.setName("Scion");
+
+        user = new User("super", "duper", Collections.singletonList(new SimpleGrantedAuthority("PLAYER")));
+
+        verb = new Verb();
+        verb.setName("super");
+        verb.setBean("verbCommand");
+        verb.getRoles().add(new Role("PLAYER"));
+
+        when(verbRepository.findFirstByNameIgnoreCaseStartingWith(any(Sort.class), eq("super"))).thenReturn(Optional.of(verb));
+        when(userDetailsManager.loadUserByUsername(eq("Scion"))).thenReturn(user);
+
+        command = new SuperCommand(userDetailsManager, creatureRepository, verbRepository);
+    }
+
+    @Test
+    void testSuperActive() {
+        command.invoke(creature, output);
+
+        verify(userDetailsManager).updateUser(any(UserDetails.class));
+        verify(creatureRepository).save(any());
+        verify(verbRepository).save(any());
+    }
+
+    @Test
+    void testSuperInactive() {
+        verb.getRoles().clear();
+
+        command.invoke(creature, output);
+
+        verifyZeroInteractions(userDetailsManager);
+        verifyZeroInteractions(creatureRepository);
+        verify(verbRepository, never()).save(any());
+    }
+}

--- a/src/test/java/com/agonyforge/core/controller/interpret/delegate/login/DefaultLoginInterpreterDelegateTest.java
+++ b/src/test/java/com/agonyforge/core/controller/interpret/delegate/login/DefaultLoginInterpreterDelegateTest.java
@@ -13,6 +13,7 @@ import com.agonyforge.core.model.Gender;
 import com.agonyforge.core.model.repository.ConnectionRepository;
 import com.agonyforge.core.model.repository.CreatureDefinitionRepository;
 import com.agonyforge.core.model.repository.CreatureRepository;
+import com.agonyforge.core.model.repository.RoleRepository;
 import com.agonyforge.core.service.CommService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -25,11 +26,13 @@ import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.provisioning.UserDetailsManager;
 import org.springframework.session.Session;
 import org.springframework.session.SessionRepository;
 import org.springframework.util.StringUtils;
 
+import java.util.Collections;
 import java.util.Date;
 import java.util.Optional;
 import java.util.UUID;
@@ -63,6 +66,9 @@ class DefaultLoginInterpreterDelegateTest {
     private CreatureDefinitionRepository creatureDefinitionRepository;
 
     @Mock
+    private RoleRepository roleRepository;
+
+    @Mock
     private CommService commService;
 
     @Mock
@@ -84,7 +90,12 @@ class DefaultLoginInterpreterDelegateTest {
         MockitoAnnotations.initMocks(this);
 
         LoginConfiguration loginConfiguration = new LoginConfigurationBuilder().build();
-        CreatureFactory creatureFactory = new CreatureFactory(commService, creatureRepository, connectionRepository);
+        CreatureFactory creatureFactory = new CreatureFactory(
+            commService,
+            creatureRepository,
+            connectionRepository,
+            roleRepository,
+            userDetailsManager);
 
         when(primary.prompt(any(Connection.class))).thenAnswer(invocation -> {
             Connection connection = invocation.getArgument(0);
@@ -129,6 +140,11 @@ class DefaultLoginInterpreterDelegateTest {
 
             return definition;
         });
+
+        UserDetails user = mock(UserDetails.class);
+
+        when(user.getAuthorities()).thenReturn(Collections.emptyList());
+        when(userDetailsManager.loadUserByUsername(anyString())).thenReturn(user);
 
         interpreter = new DefaultLoginInterpreterDelegate(
             loginConfiguration,

--- a/src/test/java/com/agonyforge/core/model/factory/CreatureFactoryTest.java
+++ b/src/test/java/com/agonyforge/core/model/factory/CreatureFactoryTest.java
@@ -7,12 +7,16 @@ import com.agonyforge.core.model.CreatureDefinition;
 import com.agonyforge.core.model.Gender;
 import com.agonyforge.core.model.repository.ConnectionRepository;
 import com.agonyforge.core.model.repository.CreatureRepository;
+import com.agonyforge.core.model.repository.RoleRepository;
 import com.agonyforge.core.service.CommService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.provisioning.UserDetailsManager;
 
+import java.util.Collections;
 import java.util.UUID;
 import java.util.stream.Stream;
 
@@ -35,6 +39,12 @@ class CreatureFactoryTest {
     @Mock
     private ConnectionRepository connectionRepository;
 
+    @Mock
+    private RoleRepository roleRepository;
+
+    @Mock
+    private UserDetailsManager userDetailsManager;
+
     private CreatureFactory creatureFactory;
 
     @BeforeEach
@@ -51,7 +61,17 @@ class CreatureFactoryTest {
             return creature;
         });
 
-        creatureFactory = new CreatureFactory(commService, creatureRepository, connectionRepository);
+        UserDetails user = mock(UserDetails.class);
+
+        when(user.getAuthorities()).thenReturn(Collections.emptyList());
+        when(userDetailsManager.loadUserByUsername(anyString())).thenReturn(user);
+
+        creatureFactory = new CreatureFactory(
+            commService,
+            creatureRepository,
+            connectionRepository,
+            roleRepository,
+            userDetailsManager);
     }
 
     @Test

--- a/src/test/java/com/agonyforge/core/service/InvokerServiceTest.java
+++ b/src/test/java/com/agonyforge/core/service/InvokerServiceTest.java
@@ -1,12 +1,19 @@
 package com.agonyforge.core.service;
 
 import com.agonyforge.core.controller.Output;
+import com.agonyforge.core.controller.interpret.delegate.game.binding.QuotedString;
+import com.agonyforge.core.controller.interpret.delegate.game.binding.VerbBinding;
+import com.agonyforge.core.controller.interpret.delegate.game.command.GossipCommand;
+import com.agonyforge.core.controller.interpret.delegate.game.command.HelpCommand;
 import com.agonyforge.core.controller.interpret.delegate.game.command.WhoCommand;
 import com.agonyforge.core.model.Creature;
+import com.agonyforge.core.model.Role;
 import com.agonyforge.core.model.Verb;
 import com.agonyforge.core.model.repository.VerbRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.springframework.context.ApplicationContext;
@@ -15,7 +22,10 @@ import org.springframework.data.domain.Sort;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
@@ -30,8 +40,12 @@ class InvokerServiceTest {
     @Mock
     private WhoCommand whoCommand;
 
+    @Captor
+    private ArgumentCaptor<QuotedString> quotedStringCaptor;
+
     private Creature ch;
     private Output output;
+    private Verb verb;
 
     private InvokerService invokerService;
 
@@ -41,11 +55,13 @@ class InvokerServiceTest {
 
         ch = new Creature();
         output = new Output();
+        verb = new Verb();
 
-        Verb verb = new Verb();
+        ch.getRoles().add(new Role("PLAYER"));
 
         verb.setName("who");
         verb.setBean("whoCommand");
+        verb.getRoles().add(new Role("PLAYER"));
 
         when(verbRepository.findFirstByNameIgnoreCaseStartingWith(any(Sort.class), eq("WHO"))).thenReturn(Optional.of(verb));
         when(applicationContext.getBean(eq("whoCommand"))).thenReturn(whoCommand);
@@ -86,5 +102,54 @@ class InvokerServiceTest {
 
         verify(verbRepository).findFirstByNameIgnoreCaseStartingWith(any(), eq("WHO"));
         verify(whoCommand).invoke(eq(ch), eq(output));
+    }
+
+    @Test
+    void testNoValidRole() {
+        verb.getRoles().clear();
+        verb.getRoles().add(new Role("FANCY"));
+
+        invokerService.invoke(ch, output, "who", Collections.singletonList("WHO"));
+
+        verify(verbRepository).findFirstByNameIgnoreCaseStartingWith(any(), eq("WHO"));
+        verify(whoCommand, never()).invoke(eq(ch), eq(output));
+    }
+
+    @Test
+    void testQuotingVerb() {
+        GossipCommand gossipCommand = mock(GossipCommand.class);
+
+        when(applicationContext.getBean(eq("gossipCommand"))).thenReturn(gossipCommand);
+        when(applicationContext.getBean(eq(QuotedString.class))).thenAnswer(i -> new QuotedString());
+
+        verb.setQuoting(true);
+        verb.setBean("gossipCommand");
+
+        invokerService.invoke(ch, output, "who do you think you are?", Stream
+            .of("WHO", "DO", "YOU", "THINK", "YOU", "ARE")
+            .collect(Collectors.toList()));
+
+        verify(verbRepository).findFirstByNameIgnoreCaseStartingWith(any(), eq("WHO"));
+        verify(gossipCommand).invoke(eq(ch), eq(output), quotedStringCaptor.capture());
+
+        QuotedString quotedString = quotedStringCaptor.getValue();
+
+        assertEquals("do you think you are?", quotedString.getToken());
+    }
+
+    @Test
+    void testFailedBinding() {
+        HelpCommand helpCommand = mock(HelpCommand.class);
+
+        when(verbRepository.findFirstByNameIgnoreCaseStartingWith(any(Sort.class), eq("HELP"))).thenReturn(Optional.of(verb));
+        when(applicationContext.getBean(eq("helpCommand"))).thenReturn(helpCommand);
+        when(applicationContext.getBean(eq(VerbBinding.class))).thenAnswer(i -> new VerbBinding(verbRepository));
+
+        verb.setBean("helpCommand");
+
+        invokerService.invoke(ch, output, "help me", Stream.of("HELP", "ME").collect(Collectors.toList()));
+
+        verify(verbRepository).findFirstByNameIgnoreCaseStartingWith(any(), eq("HELP"));
+        verify(helpCommand, never()).invoke(eq(ch), eq(output));
     }
 }


### PR DESCRIPTION
* Roles associate with verbs and users to define which verbs are available to a player
* The SUPER role allow a player to use any command (i.e. root access!)
* By default all players get the PLAYER role
* The three commands that exist now all have the PLAYER role
* If you try to use a verb that you don't have an appropriate role for, it won't run
* SUPER command to add the SUPER role to one player, deactivates automatically after first use