### PR TITLE
Room exits

### DIFF
--- a/src/main/java/com/agonyforge/core/controller/interpret/delegate/game/command/LookCommand.java
+++ b/src/main/java/com/agonyforge/core/controller/interpret/delegate/game/command/LookCommand.java
@@ -31,5 +31,21 @@ public class LookCommand {
         output
             .append(String.format("[yellow]&lsqb;%s#%s&rsqb; A Room", room.getZone().getId(), room.getSequence()))
             .append("[dwhite]Room description.");
+
+        StringBuilder buf = new StringBuilder("[cyan]Exits: ");
+
+        if (!room.getExits().isEmpty()) {
+            room.getExits().keySet()
+                .stream()
+                .sorted()
+                .forEach(direction -> {
+                    buf.append(direction.getName());
+                    buf.append(" ");
+                });
+        } else {
+            buf.append("none");
+        }
+
+        output.append(buf.toString().trim());
     }
 }

--- a/src/main/java/com/agonyforge/core/model/Creature.java
+++ b/src/main/java/com/agonyforge/core/model/Creature.java
@@ -40,7 +40,7 @@ public class Creature {
     @OneToOne(cascade = CascadeType.ALL)
     private Connection connection;
 
-    @ManyToOne(cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY)
     private Room room;
 
     public UUID getId() {

--- a/src/main/java/com/agonyforge/core/model/Direction.java
+++ b/src/main/java/com/agonyforge/core/model/Direction.java
@@ -1,0 +1,78 @@
+package com.agonyforge.core.model;
+
+import com.agonyforge.core.model.util.BaseEnumSetConverter;
+import com.agonyforge.core.model.util.PersistentEnum;
+
+public enum Direction implements PersistentEnum {
+    NORTH(0, "north", "n", "south", 0, 1, 0),
+    EAST(1, "east", "e", "west", 1, 0, 0),
+    SOUTH(2, "south", "s", "north", 0, -1, 0),
+    WEST(3, "west", "w", "east", -1, 0, 0),
+//    NORTHWEST(4, "northwest", "nw","southeast", -1, 1, 0),
+//    NORTHEAST(5, "northeast", "ne","southwest", 1, 1, 0),
+//    SOUTHWEST(6, "southwest", "sw","northeast", -1, -1, 0),
+//    SOUTHEAST(7, "southeast", "se","northwest", 1, -1, 0),
+    UP(8, "up", "u", "down", 0, 0, 1),
+    DOWN(9, "down", "d", "up", 0, 0, -1);
+
+    private int index;
+    private String name;
+    private String abbreviation;
+    private String opposite;
+    private int x;
+    private int y;
+    private int z;
+
+    Direction(
+        int index,
+        String name,
+        String abbreviation,
+        String opposite,
+        int x,
+        int y,
+        int z) {
+
+        this.index = index;
+        this.name = name;
+        this.abbreviation = abbreviation;
+        this.opposite = opposite;
+        this.x = x;
+        this.y = y;
+        this.z = z;
+    }
+
+    @Override
+    public int getIndex() {
+        return index;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getAbbreviation() {
+        return abbreviation;
+    }
+
+    public String getOpposite() {
+        return opposite;
+    }
+
+    public int getX() {
+        return x;
+    }
+
+    public int getY() {
+        return y;
+    }
+
+    public int getZ() {
+        return z;
+    }
+
+    public static class Converter extends BaseEnumSetConverter<Direction> {
+        public Converter() {
+            super(Direction.class);
+        }
+    }
+}

--- a/src/main/java/com/agonyforge/core/model/Portal.java
+++ b/src/main/java/com/agonyforge/core/model/Portal.java
@@ -4,8 +4,10 @@ import org.hibernate.annotations.GenericGenerator;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
+import javax.persistence.ManyToOne;
 import javax.persistence.Table;
 import java.util.Objects;
 import java.util.UUID;
@@ -19,12 +21,31 @@ public class Portal {
     @Column(columnDefinition = "BINARY(16)")
     private UUID id;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Room room;
+
+    public Portal() {
+        // this method intentionally left blank
+    }
+
+    public Portal(Room room) {
+        setRoom(room);
+    }
+
     public UUID getId() {
         return id;
     }
 
     public void setId(UUID id) {
         this.id = id;
+    }
+
+    public Room getRoom() {
+        return room;
+    }
+
+    public void setRoom(Room room) {
+        this.room = room;
     }
 
     @Override

--- a/src/main/java/com/agonyforge/core/model/Portal.java
+++ b/src/main/java/com/agonyforge/core/model/Portal.java
@@ -1,0 +1,42 @@
+package com.agonyforge.core.model;
+
+import org.hibernate.annotations.GenericGenerator;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import java.util.Objects;
+import java.util.UUID;
+
+@Entity
+@Table(name = "portal")
+public class Portal {
+    @Id
+    @GeneratedValue(generator = "uuid2")
+    @GenericGenerator(name = "uuid2", strategy = "uuid2")
+    @Column(columnDefinition = "BINARY(16)")
+    private UUID id;
+
+    public UUID getId() {
+        return id;
+    }
+
+    public void setId(UUID id) {
+        this.id = id;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof Portal)) return false;
+        Portal portal = (Portal) o;
+        return Objects.equals(getId(), portal.getId());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getId());
+    }
+}

--- a/src/main/java/com/agonyforge/core/model/Room.java
+++ b/src/main/java/com/agonyforge/core/model/Room.java
@@ -34,13 +34,22 @@ public class Room {
     private Zone zone;
 
     @SuppressWarnings("JpaAttributeTypeInspection")
-    @ElementCollection
+    @ElementCollection(fetch = FetchType.LAZY)
     @MapKeyColumn(name = "exit_type")
     @MapKeyEnumerated(EnumType.STRING)
     private Map<Direction, Portal> exits = new HashMap<>();
 
     @OneToMany(mappedBy = "room")
     private List<Creature> creatures = new ArrayList<>();
+
+    public Room() {
+        // this method intentionally left blank
+    }
+
+    public Room(Zone zone, int sequence) {
+        setZone(zone);
+        setSequence(sequence);
+    }
 
     public UUID getId() {
         return id;

--- a/src/main/java/com/agonyforge/core/model/Room.java
+++ b/src/main/java/com/agonyforge/core/model/Room.java
@@ -3,14 +3,20 @@ package com.agonyforge.core.model;
 import org.hibernate.annotations.GenericGenerator;
 
 import javax.persistence.Column;
+import javax.persistence.ElementCollection;
 import javax.persistence.Entity;
+import javax.persistence.EnumType;
 import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.ManyToOne;
+import javax.persistence.MapKeyColumn;
+import javax.persistence.MapKeyEnumerated;
 import javax.persistence.OneToMany;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.UUID;
 
@@ -26,6 +32,12 @@ public class Room {
 
     @ManyToOne(fetch = FetchType.LAZY)
     private Zone zone;
+
+    @SuppressWarnings("JpaAttributeTypeInspection")
+    @ElementCollection
+    @MapKeyColumn(name = "exit_type")
+    @MapKeyEnumerated(EnumType.STRING)
+    private Map<Direction, Portal> exits = new HashMap<>();
 
     @OneToMany(mappedBy = "room")
     private List<Creature> creatures = new ArrayList<>();
@@ -52,6 +64,14 @@ public class Room {
 
     public void setZone(Zone zone) {
         this.zone = zone;
+    }
+
+    public Map<Direction, Portal> getExits() {
+        return exits;
+    }
+
+    public void setExits(Map<Direction, Portal> exits) {
+        this.exits = exits;
     }
 
     public List<Creature> getCreatures() {

--- a/src/main/java/com/agonyforge/core/model/factory/ZoneFactory.java
+++ b/src/main/java/com/agonyforge/core/model/factory/ZoneFactory.java
@@ -1,7 +1,10 @@
 package com.agonyforge.core.model.factory;
 
+import com.agonyforge.core.model.Direction;
+import com.agonyforge.core.model.Portal;
 import com.agonyforge.core.model.Room;
 import com.agonyforge.core.model.Zone;
+import com.agonyforge.core.model.repository.PortalRepository;
 import com.agonyforge.core.model.repository.RoomRepository;
 import com.agonyforge.core.model.repository.ZoneRepository;
 import org.slf4j.Logger;
@@ -21,11 +24,17 @@ public class ZoneFactory {
 
     private ZoneRepository zoneRepository;
     private RoomRepository roomRepository;
+    private PortalRepository portalRepository;
 
     @Inject
-    public ZoneFactory(ZoneRepository zoneRepository, RoomRepository roomRepository) {
+    public ZoneFactory(
+        ZoneRepository zoneRepository,
+        RoomRepository roomRepository,
+        PortalRepository portalRepository) {
+
         this.zoneRepository = zoneRepository;
         this.roomRepository = roomRepository;
+        this.portalRepository = portalRepository;
     }
 
     public Zone getStartZone() {
@@ -44,9 +53,11 @@ public class ZoneFactory {
 
         for (int i = 0; i < ZONE_SIZE; i++) {
             Room room = new Room();
+            Portal exit = portalRepository.save(new Portal());
 
             room.setZone(zone);
             room.setSequence(i);
+            room.getExits().put(Direction.EAST, exit);
 
             rooms.add(room);
         }

--- a/src/main/java/com/agonyforge/core/model/factory/ZoneFactory.java
+++ b/src/main/java/com/agonyforge/core/model/factory/ZoneFactory.java
@@ -52,12 +52,16 @@ public class ZoneFactory {
         List<Room> rooms = new ArrayList<>();
 
         for (int i = 0; i < ZONE_SIZE; i++) {
-            Room room = new Room();
-            Portal exit = portalRepository.save(new Portal());
+            Room room = roomRepository.save(new Room(zone, i));
 
-            room.setZone(zone);
-            room.setSequence(i);
-            room.getExits().put(Direction.EAST, exit);
+            if (i > 0) {
+                Room last = rooms.get(i - 1);
+                Portal forwardExit = portalRepository.save(new Portal(last));
+                Portal reciprocalExit = portalRepository.save(new Portal(room));
+
+                last.getExits().put(Direction.EAST, reciprocalExit);
+                room.getExits().put(Direction.WEST, forwardExit);
+            }
 
             rooms.add(room);
         }

--- a/src/main/java/com/agonyforge/core/model/repository/PortalRepository.java
+++ b/src/main/java/com/agonyforge/core/model/repository/PortalRepository.java
@@ -1,0 +1,9 @@
+package com.agonyforge.core.model.repository;
+
+import com.agonyforge.core.model.Portal;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface PortalRepository extends JpaRepository<Portal, UUID> {
+}

--- a/src/main/resources/db/migration/V0007__portal_schema.sql
+++ b/src/main/resources/db/migration/V0007__portal_schema.sql
@@ -1,6 +1,8 @@
 CREATE TABLE portal (
     id BINARY(16) NOT NULL,
-    PRIMARY KEY (id)
+    room_id BINARY(16) NOT NULL,
+    PRIMARY KEY (id),
+    CONSTRAINT portal_room_fk FOREIGN KEY (room_id) REFERENCES room (id)
 ) ENGINE=InnoDB CHARACTER SET=utf8mb4, COLLATE=utf8mb4_unicode_ci;
 
 CREATE TABLE room_exits (

--- a/src/main/resources/db/migration/V0007__portal_schema.sql
+++ b/src/main/resources/db/migration/V0007__portal_schema.sql
@@ -1,0 +1,14 @@
+CREATE TABLE portal (
+    id BINARY(16) NOT NULL,
+    PRIMARY KEY (id)
+) ENGINE=InnoDB CHARACTER SET=utf8mb4, COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE room_exits (
+    room_id BINARY(16) NOT NULL,
+    exit_type VARCHAR(191) NOT NULL,
+    exits_id BINARY(16) NOT NULL,
+    PRIMARY KEY (room_id, exits_id),
+    CONSTRAINT room_exits_1_fk FOREIGN KEY (room_id) REFERENCES room (id),
+    CONSTRAINT room_exits_2_fk FOREIGN KEY (exits_id) REFERENCES portal (id)
+) ENGINE=InnoDB CHARACTER SET=utf8mb4, COLLATE=utf8mb4_unicode_ci;
+

--- a/src/test/java/com/agonyforge/core/model/factory/ZoneFactoryTest.java
+++ b/src/test/java/com/agonyforge/core/model/factory/ZoneFactoryTest.java
@@ -52,6 +52,16 @@ class ZoneFactoryTest {
             return zone;
         });
 
+        when(roomRepository.save(any())).thenAnswer(invocation -> {
+            Room room = invocation.getArgument(0);
+
+            if (room.getId() == null) {
+                room.setId(UUID.randomUUID());
+            }
+
+            return room;
+        });
+
         when(roomRepository.saveAll(anyList())).thenAnswer(invocation -> {
             List<Room> rooms = invocation.getArgument(0);
 

--- a/src/test/java/com/agonyforge/core/model/factory/ZoneFactoryTest.java
+++ b/src/test/java/com/agonyforge/core/model/factory/ZoneFactoryTest.java
@@ -1,7 +1,9 @@
 package com.agonyforge.core.model.factory;
 
+import com.agonyforge.core.model.Portal;
 import com.agonyforge.core.model.Room;
 import com.agonyforge.core.model.Zone;
+import com.agonyforge.core.model.repository.PortalRepository;
 import com.agonyforge.core.model.repository.RoomRepository;
 import com.agonyforge.core.model.repository.ZoneRepository;
 import org.junit.jupiter.api.BeforeEach;
@@ -26,6 +28,9 @@ class ZoneFactoryTest {
 
     @Mock
     private RoomRepository roomRepository;
+
+    @Mock
+    private PortalRepository portalRepository;
 
     private long nextZoneId = 1;
 
@@ -57,7 +62,20 @@ class ZoneFactoryTest {
             return rooms;
         });
 
-        zoneFactory = new ZoneFactory(zoneRepository, roomRepository);
+        when(portalRepository.save(any())).thenAnswer(invocation -> {
+            Portal portal = invocation.getArgument(0);
+
+            if (portal.getId() == null) {
+                portal.setId(UUID.randomUUID());
+            }
+
+            return portal;
+        });
+
+        zoneFactory = new ZoneFactory(
+            zoneRepository,
+            roomRepository,
+            portalRepository);
     }
 
     @Test


### PR DESCRIPTION
Adds schema for "portals", which are single-direction pointers to rooms. Rooms have a `Map<Direction, Portal>` to hold "exits". Once I get around to making the directional commands these exits will inform the command which room to go to when you decide to travel in that direction.

Portals will be able to be used for other non-directional kinds of travel as well, like into a building or across to another zone. Another example might be a spell that creates a temporary portal from one place to another.