### PR TITLE
Switch to HazelCast for Spring sessions instead of JDBC

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,8 @@ dependencies {
     implementation 'mysql:mysql-connector-java:8.0.29'
     implementation 'org.flywaydb:flyway-mysql:8.5.13'
 
+    implementation 'com.hazelcast:hazelcast:5.1.2'
+
     implementation 'org.springframework.boot:spring-boot-starter'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.springframework.boot:spring-boot-starter-freemarker'
@@ -46,7 +48,7 @@ dependencies {
     implementation 'org.springframework.security:spring-security-taglibs'
     implementation 'org.eclipse.jetty:apache-jsp:11.0.11'
 
-    implementation 'org.springframework.session:spring-session-jdbc'
+    implementation 'org.springframework.session:spring-session-hazelcast'
 
     implementation 'io.projectreactor.netty:reactor-netty:1.0.20'
 

--- a/build.gradle
+++ b/build.gradle
@@ -51,6 +51,7 @@ dependencies {
     implementation 'org.springframework.session:spring-session-hazelcast'
 
     implementation 'io.projectreactor.netty:reactor-netty:1.0.20'
+    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.13.3'
 
     implementation 'org.webjars:webjars-locator-core:0.52'
     implementation 'org.webjars:jquery:3.6.0'

--- a/src/main/java/com/agonyforge/core/AgonyForge.java
+++ b/src/main/java/com/agonyforge/core/AgonyForge.java
@@ -2,16 +2,11 @@ package com.agonyforge.core;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.web.servlet.view.freemarker.FreeMarkerConfigurer;
+import org.springframework.cache.annotation.EnableCaching;
 
-import static java.util.Collections.singletonList;
-
+@EnableCaching
 @SpringBootApplication
 public class AgonyForge {
-    public AgonyForge(FreeMarkerConfigurer freeMarkerConfigurer) {
-        freeMarkerConfigurer.getTaglibFactory().setClasspathTlds(singletonList("/META-INF/security.tld"));
-        freeMarkerConfigurer.getTaglibFactory().setObjectWrapper(freeMarkerConfigurer.getConfiguration().getObjectWrapper());
-    }
     public static void main(String ... args) {
         SpringApplication.run(AgonyForge.class, args);
     }

--- a/src/main/java/com/agonyforge/core/config/SessionConfiguration.java
+++ b/src/main/java/com/agonyforge/core/config/SessionConfiguration.java
@@ -1,9 +1,21 @@
 package com.agonyforge.core.config;
 
+import com.hazelcast.config.Config;
+import com.hazelcast.core.Hazelcast;
+import com.hazelcast.core.HazelcastInstance;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.session.jdbc.config.annotation.web.http.EnableJdbcHttpSession;
+import org.springframework.session.hazelcast.config.annotation.web.http.EnableHazelcastHttpSession;
 
-@EnableJdbcHttpSession(maxInactiveIntervalInSeconds = 86400)
+@EnableHazelcastHttpSession
 @Configuration
 public class SessionConfiguration {
+    @Bean
+    public HazelcastInstance hazelcastInstance() {
+        Config config = new Config();
+
+        config.setClusterName("agony-forge-sessions");
+
+        return Hazelcast.newHazelcastInstance(config);
+    }
 }

--- a/src/main/java/com/agonyforge/core/config/WebSecurityConfiguration.java
+++ b/src/main/java/com/agonyforge/core/config/WebSecurityConfiguration.java
@@ -8,6 +8,8 @@ import org.springframework.security.config.annotation.authentication.builders.Au
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.core.session.SessionRegistry;
+import org.springframework.security.core.session.SessionRegistryImpl;
 import org.springframework.security.provisioning.UserDetailsManager;
 import org.springframework.security.web.authentication.logout.SecurityContextLogoutHandler;
 
@@ -64,6 +66,14 @@ public class WebSecurityConfiguration extends WebSecurityConfigurerAdapter {
                 .authenticated())
             .oauth2Login(conf -> conf
                 .loginPage("/")
-                .defaultSuccessUrl("/"));
+                .defaultSuccessUrl("/"))
+            .sessionManagement()
+            .maximumSessions(2)
+            .sessionRegistry(sessionRegistry());
+    }
+
+    @Bean
+    public SessionRegistry sessionRegistry() {
+        return new SessionRegistryImpl();
     }
 }

--- a/src/main/java/com/agonyforge/core/controller/interpret/delegate/game/command/SessionsCommand.java
+++ b/src/main/java/com/agonyforge/core/controller/interpret/delegate/game/command/SessionsCommand.java
@@ -1,0 +1,74 @@
+package com.agonyforge.core.controller.interpret.delegate.game.command;
+
+import com.agonyforge.core.controller.Output;
+import com.agonyforge.core.controller.interpret.delegate.game.binding.PlayerBinding;
+import com.agonyforge.core.model.Creature;
+import com.agonyforge.core.model.repository.CreatureRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.security.core.session.SessionInformation;
+import org.springframework.security.core.session.SessionRegistry;
+import org.springframework.security.oauth2.core.oidc.user.DefaultOidcUser;
+import org.springframework.stereotype.Component;
+
+import javax.inject.Inject;
+import javax.transaction.Transactional;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Component
+public class SessionsCommand {
+    private static final Logger LOGGER = LoggerFactory.getLogger(SessionsCommand.class);
+
+    final private SessionRegistry sessionRegistry;
+    final private CreatureRepository creatureRepository;
+
+    @Inject
+    public SessionsCommand(SessionRegistry sessionRegistry, CreatureRepository creatureRepository) {
+        this.sessionRegistry = sessionRegistry;
+        this.creatureRepository = creatureRepository;
+    }
+
+    @Transactional
+    @CommandDescription("Lists session information for one player")
+    public void invoke(Creature actor, Output output, PlayerBinding playerBinding) {
+        Creature target = playerBinding.getPlayer();
+        displayPlayerInfo(target, output);
+    }
+
+    @Transactional
+    @CommandDescription("Lists session information for all players")
+    public void invoke(Creature actor, Output output) {
+        List<Creature> players = creatureRepository.findByConnectionIsNotNull()
+            .sorted((o1, o2) -> o1.getName().compareToIgnoreCase(o2.getName()))
+            .collect(Collectors.toList());
+
+        output.append("[dcyan]--= Active Players =--");
+        players.forEach(player -> displayPlayerInfo(player, output));
+    }
+
+    private void displayPlayerInfo(Creature player, Output output) {
+        SessionInformation info = sessionRegistry.getSessionInformation(player.getConnection().getHttpSessionId());
+        DefaultOidcUser user = null;
+
+        if (info != null && info.getPrincipal() instanceof DefaultOidcUser) {
+            user = (DefaultOidcUser) info.getPrincipal();
+        }
+
+        output
+            .append(String.format("[yellow]%s: [dyellow]OAuth UUID: %s [cyan]Websocket ID: %s",
+                player.getName(),
+                player.getConnection().getHttpSessionId(),
+                player.getConnection().getSessionId()))
+            .append(String.format("[yellow]IP Address: [dyellow]%s", player.getConnection().getRemoteAddress()));
+
+        if (user != null) {
+            output.append(String.format("[yellow]Name: [dyellow]%s", user.getName()));
+            output.append(String.format("[yellow]Given Name: [dyellow]%s", user.getGivenName()));
+            output.append(String.format("[yellow]Email: [dyellow]%s", user.getEmail()));
+
+            // TODO make this optional with an optional command argument
+            output.append(String.format("[white]%s", user));
+        }
+    }
+}

--- a/src/main/java/com/agonyforge/core/model/Verb.java
+++ b/src/main/java/com/agonyforge/core/model/Verb.java
@@ -88,7 +88,7 @@ public class Verb {
 
                         buf.append("&lt;");
                         buf.append(description == null ? "argument" : description.value());
-                        buf.append("&gt;");
+                        buf.append("&gt;&nbsp;");
                     }
                 }
 

--- a/src/main/resources/db/migration/R__verbs.sql
+++ b/src/main/resources/db/migration/R__verbs.sql
@@ -14,6 +14,7 @@ INSERT IGNORE INTO verb (name, priority, bean) VALUES ('look', 10, 'lookCommand'
 INSERT IGNORE INTO verb (name, priority, bean, quoting) VALUES ('say', 10, 'sayCommand', TRUE);
 INSERT IGNORE INTO verb (name, priority, bean) VALUES ('who', 10, 'whoCommand');
 INSERT IGNORE INTO verb (name, priority, bean) VALUES ('goto', 1000, 'gotoCommand');
+INSERT IGNORE INTO verb (name, priority, bean) VALUES ('sessions', 1000, 'sessionsCommand');
 INSERT IGNORE INTO verb (name, priority, bean) VALUES ('super', 1000, 'superCommand');
 INSERT IGNORE INTO verb (name, priority, bean) VALUES ('crash', 1000, 'crashCommand');
 
@@ -36,3 +37,4 @@ INSERT IGNORE INTO verb_roles (verb_name, roles_name) VALUES ('who', 'PLAYER');
 INSERT IGNORE INTO verb_roles (verb_name, roles_name) VALUES ('goto', 'PLAYER');
 INSERT IGNORE INTO verb_roles (verb_name, roles_name) VALUES ('super', 'PLAYER');
 INSERT IGNORE INTO verb_roles (verb_name, roles_name) VALUES ('crash', 'SUPER');
+INSERT IGNORE INTO verb_roles (verb_name, roles_name) VALUES ('sessions', 'SUPER');

--- a/src/main/resources/templates/inc/security.inc.ftlh
+++ b/src/main/resources/templates/inc/security.inc.ftlh
@@ -1,0 +1,30 @@
+<!-- Adapted from https://github.com/spring-projects/spring-security/issues/3275 -->
+<#macro secure roleName>
+    <#assign authorized = false>
+    <#if SPRING_SECURITY_CONTEXT??>
+        <#list SPRING_SECURITY_CONTEXT.authentication.authorities as authority>
+            <#if authority == roleName>
+                <#assign authorized = true>
+            </#if>
+        </#list>
+        <#if authorized>
+            <#nested>
+        </#if>
+    </#if>
+</#macro>
+
+<#macro anonymous roleName>
+    <#assign authorized = false>
+    <#if SPRING_SECURITY_CONTEXT??>
+        <#list SPRING_SECURITY_CONTEXT.authentication.authorities as authority>
+            <#if authority == roleName>
+                <#assign authorized = true>
+            </#if>
+        </#list>
+        <#if authorized == false>
+            <#nested>
+        </#if>
+    <#else>
+        <#nested>
+    </#if>
+</#macro>

--- a/src/main/resources/templates/play.ftlh
+++ b/src/main/resources/templates/play.ftlh
@@ -1,5 +1,5 @@
 <#import "/spring.ftl" as spring>
-<#assign security=JspTaglibs["http://www.springframework.org/security/tags"] />
+<#include "inc/security.inc.ftlh">
 <!DOCTYPE html>
 <html lang="en">
 <#assign title="Play">
@@ -12,12 +12,12 @@
         Javascript being enabled. Please enable Javascript and reload this page!
     </span>
 </noscript>
-<@security.authorize access="isAnonymous()">
+<@anonymous "ROLE_USER">
 <div class="container-fluid">
     <a class="btn btn-primary" role="button" href="<@spring.url '/oauth2/authorization/cognito' />">Login</a>
 </div>
-</@security.authorize>
-<@security.authorize access="isAuthenticated()">
+</@anonymous>
+<@secure "ROLE_USER">
 <div>
     <div id="output-box">
         <ul id="output-list">
@@ -29,13 +29,13 @@
         </form>
     </div>
 </div>
-</@security.authorize>
+</@secure>
 
 <#include "inc/scripts.inc.ftlh">
-<@security.authorize access="isAuthenticated()">
+<@secure "ROLE_USER">
 <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/sockjs-client@1.6.1/dist/sockjs.min.js"></script>
 <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/webstomp-client@1.2.6/dist/webstomp.min.js"></script>
 <script type="text/javascript" src="<@spring.url '/js/client.js'/>"></script>
-</@security.authorize>
+</@secure>
 </body>
 </html>


### PR DESCRIPTION
Long term: moving from JDBC to DynamoDB.
Short term: stop using JDBC sessions and start using HazelCast sessions.

Spring Security and FreeMarker and JSP Taglibs don't work nicely together, and the Spring developers have commented saying they won't fix it and that JSP is "an inferior technology" so we're on our own. Fortunately the spring security context is available in FreeMarker and we can just write some macros to check whether the user is authenticated or anonymous.

Putting this in draft for now because I have not yet tested two servers together and confirmed that HazelCast does in fact connect them together and share their sessions.